### PR TITLE
Skip job if package is not on CRAN

### DIFF
--- a/script.R
+++ b/script.R
@@ -68,7 +68,7 @@ pkg_name <- read.dcf("DESCRIPTION")[1, "Package"][[1]]
 tryCatch(
   crancache::install_packages(pkg_name, quiet = TRUE),
   warning = function(w) {
-    if (grepl('package.*is not available for this version of R', w$message)) {
+    if (grepl("package.*is not available for this version of R", w$message)) {
       q()
     } else {
       stop(w$message)

--- a/script.R
+++ b/script.R
@@ -65,7 +65,17 @@ cli::cli_progress_bar()
 # cache pkg and its dependencies
 cli::cli_progress_step("Installing the package...")
 pkg_name <- read.dcf("DESCRIPTION")[1, "Package"][[1]]
-crancache::install_packages(pkg_name, quiet = TRUE)
+tryCatch(
+  crancache::install_packages(pkg_name, quiet = TRUE),
+  warning = function(w) {
+    if (grepl('package.*is not available for this version of R', w$message)) {
+      q()
+    } else {
+      stop(w$message)
+    }
+  }
+)
+
 
 ## revdepcheck
 cli::cli_progress_step("Initiating `revdepcheck`...")


### PR DESCRIPTION
Skips the job if the package is not on CRAN. Related to packages like `teal.osprey` or `teal.goshawk`