### PR TITLE
Fix non cran2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,10 +45,7 @@ runs:
           export $(tr '\n' ' ' < /tmp/dotenv.env)
         }
         fi
-        echo ".libPaths(\" \", include.site = FALSE)" > .Rprofile
-        export R_LIBS_SITE=" "
-        export R_LIBS_USER=" "
-        time Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.number-of-workers }}' '${{ inputs.timeout }}'
+        Rscript ${GITHUB_ACTION_PATH}/script.R '${{ inputs.repository-path }}' '${{ inputs.number-of-workers }}' '${{ inputs.timeout }}'
       shell: bash
       env:
         GITHUB_PAT: "${{ inputs.github-token }}"

--- a/script.R
+++ b/script.R
@@ -10,6 +10,39 @@ if_error <- function(x, y = NULL) {
 `%||%` <- function(x, y) {
   if (!length(x) || is.null(x)) y else x
 }
+check_if_pkg_available <- function(pkg, ver) {
+  length(
+    available.packages(
+      filter = list(
+        add = TRUE,
+        function (db) {
+          db[db[, "Package"] == pkg & db[, "Version"] == ver, ]
+        }
+      )
+    )
+  ) > 0
+}
+install_and_add_to_minicran <- function(pkg, minicran_path) {
+  avail_pkgs <- rownames(available.packages())
+  x <- pak::pkg_install(pkg)
+  for (i in seq_len(nrow(x))) {
+    i_package <- x$package[i]
+    i_version <- x$version[i]
+    if (check_if_pkg_available(i_package, i_version)) next
+    i_cache <- pkgcache::pkg_cache_find(package = i_package, version = i_version, platform = "source")
+    if (nrow(i_cache) == 0) next
+    i_targz <- i_cache$fullpath[1]
+    temp_dir <- tempfile()
+    on.exit(unlink(temp_dir))
+    dir.create(temp_dir)
+    file.copy(
+      i_targz,
+      file.path(temp_dir, paste0(i_package, "_", i_version, ".tar.gz"))
+    )
+    miniCRAN::addLocalPackage(i_package, temp_dir, minicran_path)
+  }
+  invisible(NULL)
+}
 
 args <- commandArgs(trailingOnly = TRUE)
 setwd(normalizePath(file.path(args[1])))
@@ -61,12 +94,6 @@ cli::cli_bullets(refs)
 cli::cli_h1("Initiate pre-requisites")
 cli::cli_progress_bar()
 
-## install pkg
-# cache pkg and its dependencies
-cli::cli_progress_step("Installing the package...")
-pkg_name <- read.dcf("DESCRIPTION")[1, "Package"][[1]]
-crancache::install_packages(pkg_name, quiet = TRUE)
-
 ## revdepcheck
 cli::cli_progress_step("Initiating `revdepcheck`...")
 revdepcheck::revdep_reset()
@@ -79,7 +106,6 @@ revdepcheck:::db_setup(".")
 cli::cli_progress_step("Initiating `miniCRAN`...")
 minicran_path <- tempfile()
 dir.create(minicran_path)
-# added `rlang` as a dummy package as the `pkgs` arg cannot be empty
 miniCRAN::makeRepo(pkgs = "rlang", path = minicran_path, type = c("source", .Platform$pkgType))
 # add minicran repo path to repos so that revdepcheck can use it
 # this is the directory where we will store packages from config file
@@ -88,61 +114,41 @@ options("repos" = c(
   getOption("repos")
 ))
 
+## install pkg
+cli::cli_progress_step("Installing the package (CRAN)...")
+pkg_name <- read.dcf("DESCRIPTION")[, "Package"]
+pkg_ref_released <- if (pkg_name %in% rownames(available.packages())) {
+  pkg_name
+} else {
+  # @TODO: think of a better way to get ref for released version of non-CRAN packages
+  read.dcf("DESCRIPTION")[1, "URL"] |>
+    gsub("\n", "", x = _) |>
+    gsub("/$", "", x = _) |>
+    strsplit(x = _, split = ",") |>
+    _[[1]] |>
+    grep(x = _, "github.com", value = TRUE) |>
+    gsub(".*github.com/", "\\1", x = _) |>
+    paste0("@*release")
+}
+install_and_add_to_minicran(pkg_ref_released, minicran_path)
+cli::cli_progress_step("Installing the package (DEV)...")
+install_and_add_to_minicran(".", minicran_path)
+
 cli::cli_progress_done()
 
 
 cli::cli_h1("Add refs to revdepcheck")
 # include refs in revdepcheck
-## Add revdep to miniCRAN repo so that it can be found by the revdepcheck.
-## miniCRAN accepts only prebuilt .tar.gz file and build requires all the dependencies pre-installed.
-## This is why we need to install all the deps of revdep (incl. tested package).
-## It's important to use `crancache` as much as possible to make use of caching.
-## Algorithm:
-## for ref in refs:
-## - install dependencies using `crancache`
-## - install pkg using `pak` - this also gives prebuilt .tar.gz file
-## - move .tar.gz file to miniCRAN repo
-## - add to revdep todo table
+## Add refs revdepcheck and also to miniCRAN so that it can be found from there
 cli::cli_progress_bar("Adding refs to revdepcheck", total = length(refs))
 for (ref in refs) {
   cli::cli_progress_message("Adding {ref}...")
 
-  ref_parsed <- pkgdepends::parse_pkg_ref(ref)
-  ref_pkg <- ref_parsed$package
+  install_and_add_to_minicran(ref, minicran_path)
 
-  if (!is(ref_parsed, "remote_ref_standard") && !is(ref_parsed, "remote_ref_cran")) {
-    cli::cli_progress_message("Installing dependencies of {ref}...")
-    ref_deps <- pkgdepends::new_pkg_deps(ref, config = list(dependencies = FALSE))
-    ref_deps$resolve()
-    ref_deps_df <- ref_deps$get_resolution()[1, "deps"][[1]]
-    ref_deps_hard <- ref_deps_df[
-      tolower(ref_deps_df$type) %in% tolower(pkgdepends::pkg_dep_types_hard()) & ref_deps_df$ref != "R",
-      "package"
-    ]
-    crancache::install_packages(ref_deps_hard, quiet = TRUE)
-
-    cli::cli_progress_message("Installing {ref}...")
-    ref_install <- pak::pkg_install(ref)
-    ref_cache <- pkgcache::pkg_cache_find(package = ref_pkg)
-    ref_targz <- subset(
-      ref_cache,
-      (built == 1 | built == TRUE | built == "TRUE") & platform == "source" & version == ref_install$version[1],
-      fullpath
-    )[[1]]
-    # cache might have multiple files for a given package and version
-    # copy this file to the temp dir and add to miniCRAN from that dir
-    temp_dir <- tempfile()
-    dir.create(temp_dir)
-    file.copy(
-      ref_targz,
-      file.path(temp_dir, paste0(sub("(.*?_.*?)_.*", "\\1", basename(ref_targz)), ".tar.gz"))
-    )
-    miniCRAN::addLocalPackage(ref_pkg, temp_dir, minicran_path)
-
-    cli::cli_inform("Added {ref} to minicran!")
-  }
-
+  ref_pkg <- pkgdepends::parse_pkg_ref(ref)$package
   revdepcheck::revdep_add(packages = ref_pkg)
+
   cli::cli_inform("Added {ref} to revdep todo!")
   cli::cli_progress_update()
 }
@@ -182,17 +188,21 @@ catnl(readLines("revdep/cran.md", warn = FALSE))
 
 cli::cli_h2("Check duration...")
 # this does not include download and install times
-print(
-  setNames(
-    do.call(
-      rbind.data.frame,
-      lapply(
-        revdepcheck::revdep_summary(),
-        function(i) c(i$package, if_error(i$old[[1]]$duration) %||% "?", if_error(i$new$duration) %||% "?")
-      )
-    ),
-    c("package", "old", "new")
+if (length(revdepcheck::revdep_summary())) {
+  print(
+    setNames(
+      do.call(
+        rbind.data.frame,
+        lapply(
+          revdepcheck::revdep_summary(),
+          function(i) c(i$package, if_error(i$old[[1]]$duration) %||% "?", if_error(i$new$duration) %||% "?")
+        )
+      ),
+      c("package", "old", "new")
+    )
   )
-)
+} else {
+  print("(empty)")
+}
 
 stopifnot(identical(readLines("revdep/problems.md", warn = FALSE), "*Wow, no problems at all. :)*"))

--- a/script.R
+++ b/script.R
@@ -26,26 +26,36 @@ check_if_pkg_available <- function(pkg, ver = NULL) {
     ) > 0
   }
 }
-install_and_add_to_minicran <- function(pkg, minicran_path) {
-  cli::cli_inform(sprintf("Installing and adding %s to miniCRAN...", pkg))
-  x <- pak::pkg_install(pkg)
+add_to_minicran <- function(x, minicran_path) {
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir))
+  dir.create(temp_dir)
+  new_file_name <- gsub("(.*?_.*)_.*?(\\..*)", "\\1\\2", basename(x))
+  file.copy(x, file.path(temp_dir, new_file_name))
+  miniCRAN::addLocalPackage(gsub("_.*", "", basename(new_file_name)), temp_dir, minicran_path)
+  invisible(NULL)
+}
+add_cache_to_minicran <- function(pkg, version, minicran_path) {
+  i_cache <- pkgcache::pkg_cache_find(package = pkg, version = version, platform = "source")
+  if (nrow(i_cache) == 0) return(invisible(NULL))
+  cli::cli_inform(sprintf("Adding %s to miniCRAN...", pkg))
+  add_to_minicran(i_cache$fullpath[1], minicran_path)
+  invisible(NULL)
+}
+install_and_add_to_minicran <- function(ref, minicran_path) {
+  cli::cli_inform(sprintf("Installing and adding %s to miniCRAN...", ref))
+  x <- pak::pkg_install(ref)
   for (i in seq_len(nrow(x))) {
     i_package <- x$package[i]
     i_version <- x$version[i]
     if (check_if_pkg_available(i_package, i_version)) next
-    i_cache <- pkgcache::pkg_cache_find(package = i_package, version = i_version, platform = "source")
-    if (nrow(i_cache) == 0) next
-    i_targz <- i_cache$fullpath[1]
-    temp_dir <- tempfile()
-    on.exit(unlink(temp_dir))
-    dir.create(temp_dir)
-    file.copy(
-      i_targz,
-      file.path(temp_dir, paste0(i_package, "_", i_version, ".tar.gz"))
-    )
-    miniCRAN::addLocalPackage(i_package, temp_dir, minicran_path)
+    add_cache_to_minicran(i_package, i_version, minicran_path)
   }
   invisible(NULL)
+}
+is_installed_from_gh <- function(package_name) {
+  d <- packageDescription(package_name)
+  (!is.null(d$GithubSHA1)) || identical(d$RemoteType, "github")
 }
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -55,9 +65,9 @@ timeout <- as.integer(args[3])
 
 # Install required packages
 catnl("Installing required packages...")
-install.packages(c(
-  "pak"
-))
+if (!requireNamespace("pak", quietly = TRUE)) {
+  install.packages("pak")
+}
 pak::pkg_install(c(
   "cli",
   "miniCRAN",
@@ -98,14 +108,6 @@ cli::cli_bullets(refs)
 cli::cli_h1("Initiate pre-requisites")
 cli::cli_progress_bar()
 
-## revdepcheck
-cli::cli_progress_step("Initiating `revdepcheck`...")
-revdepcheck::revdep_reset()
-unlink("./revdep/", recursive = TRUE)
-revdepcheck:::db_disconnect(".")
-usethis::use_revdep()
-revdepcheck:::db_setup(".")
-
 ## miniCRAN
 cli::cli_progress_step("Initiating `miniCRAN`...")
 minicran_path <- tempfile()
@@ -119,25 +121,37 @@ options("repos" = c(
   getOption("repos")
 ))
 
-## install pkg
-cli::cli_progress_step("Installing the package (DEV)...")
-install_and_add_to_minicran(".", minicran_path)
-cli::cli_progress_step("Installing the package (CRAN)...")
+### install pkg - only if not available
 pkg_name <- read.dcf("DESCRIPTION")[, "Package"]
-pkg_ref_released <- if (check_if_pkg_available(pkg_name)) {
-  pkg_name
-} else {
+if (isFALSE(check_if_pkg_available(pkg_name))) {
+  cli::cli_progress_step("Adding GH release to miniCRAN...")
   # try to get the package reference from the DESCRIPTION file (URL field)
   pkg_url <- gsub("\n|/$", "", strsplit(read.dcf("DESCRIPTION")[1, "URL"], ",")[[1]])
   pkg_url_gh <- grep("github.com", pkg_url, value = TRUE)
-  res <- paste0(gsub(".*github.com/", "", pkg_url_gh), "@*release")
-  if (length(res) == 0) {
+  pkg_ref_released <- paste0(gsub(".*github.com/", "", pkg_url_gh), "@*release")
+  if (length(pkg_ref_released) == 0) {
     cli::cli_abort("Unable to automatically determine the package reference.")
     return(NULL)
   }
-  res
+  install_and_add_to_minicran(pkg_ref_released, minicran_path)
 }
-install_and_add_to_minicran(pkg_ref_released, minicran_path)
+
+### add pkgs from GH to miniCRAN
+cli::cli_progress_step("Adding packages from GH to miniCRAN...")
+x <- pkgdepends::new_pkg_deps(".")
+x$resolve()
+pkgs_from_gh <- Filter(is_installed_from_gh, unique(x$get_resolution()$package))
+for (pkg in pkgs_from_gh) {
+  add_cache_to_minicran(pkg, installed.packages()[pkg, "Version"], minicran_path)
+}
+
+## revdepcheck
+cli::cli_progress_step("Initiating `revdepcheck`...")
+revdepcheck::revdep_reset()
+unlink("./revdep/", recursive = TRUE)
+revdepcheck:::db_disconnect(".")
+usethis::use_revdep()
+revdepcheck:::db_setup(".")
 
 cli::cli_progress_done()
 

--- a/script.R
+++ b/script.R
@@ -10,19 +10,24 @@ if_error <- function(x, y = NULL) {
 `%||%` <- function(x, y) {
   if (!length(x) || is.null(x)) y else x
 }
-check_if_pkg_available <- function(pkg, ver) {
-  length(
-    available.packages(
-      filter = list(
-        add = TRUE,
-        function(db) {
-          db[db[, "Package"] == pkg & db[, "Version"] == ver, ]
-        }
+check_if_pkg_available <- function(pkg, ver = NULL) {
+  if (is.null(ver)) {
+    length(available.packages(filter = list(add = TRUE, function(db) db[db[, "Package"] == pkg, ]))) > 0
+  } else {
+    length(
+      available.packages(
+        filter = list(
+          add = TRUE,
+          function(db) {
+            db[db[, "Package"] == pkg & db[, "Version"] == ver, ]
+          }
+        )
       )
-    )
-  ) > 0
+    ) > 0
+  }
 }
 install_and_add_to_minicran <- function(pkg, minicran_path) {
+  cli::cli_inform(sprintf("Installing and adding %s to miniCRAN...", pkg))
   x <- pak::pkg_install(pkg)
   for (i in seq_len(nrow(x))) {
     i_package <- x$package[i]
@@ -105,6 +110,7 @@ revdepcheck:::db_setup(".")
 cli::cli_progress_step("Initiating `miniCRAN`...")
 minicran_path <- tempfile()
 dir.create(minicran_path)
+on.exit(unlink(minicran_path, recursive = TRUE))
 miniCRAN::makeRepo(pkgs = "rlang", path = minicran_path, type = c("source", .Platform$pkgType))
 # add minicran repo path to repos so that revdepcheck can use it
 # this is the directory where we will store packages from config file
@@ -114,15 +120,16 @@ options("repos" = c(
 ))
 
 ## install pkg
+cli::cli_progress_step("Installing the package (DEV)...")
+install_and_add_to_minicran(".", minicran_path)
 cli::cli_progress_step("Installing the package (CRAN)...")
 pkg_name <- read.dcf("DESCRIPTION")[, "Package"]
-pkg_ref_released <- if (pkg_name %in% rownames(available.packages())) {
+pkg_ref_released <- if (check_if_pkg_available(pkg_name)) {
   pkg_name
 } else {
-  pkg_url <- read.dcf("DESCRIPTION")[1, "URL"]
-  pkg_url_v <- strsplit(pkg_url, ",")[[1]]
-  pkg_url_v <- gsub("\n|/$", "", pkg_url_v)
-  pkg_url_gh <- grep("github.com", pkg_url_v, value = TRUE)
+  # try to get the package reference from the DESCRIPTION file (URL field)
+  pkg_url <- gsub("\n|/$", "", strsplit(read.dcf("DESCRIPTION")[1, "URL"], ",")[[1]])
+  pkg_url_gh <- grep("github.com", pkg_url, value = TRUE)
   res <- paste0(gsub(".*github.com/", "", pkg_url_gh), "@*release")
   if (length(res) == 0) {
     cli::cli_abort("Unable to automatically determine the package reference.")
@@ -131,8 +138,6 @@ pkg_ref_released <- if (pkg_name %in% rownames(available.packages())) {
   res
 }
 install_and_add_to_minicran(pkg_ref_released, minicran_path)
-cli::cli_progress_step("Installing the package (DEV)...")
-install_and_add_to_minicran(".", minicran_path)
 
 cli::cli_progress_done()
 

--- a/script.R
+++ b/script.R
@@ -123,6 +123,7 @@ cli::cli_progress_step("Initiating `miniCRAN`...")
 minicran_path <- tempfile()
 dir.create(minicran_path)
 on.exit(unlink(minicran_path, recursive = TRUE))
+# added `rlang` as a dummy package as the `pkgs` arg cannot be empty
 miniCRAN::makeRepo(pkgs = "rlang", path = minicran_path, type = c("source", .Platform$pkgType))
 # add minicran repo path to repos so that revdepcheck can use it
 # this is the directory where we will store packages from config file

--- a/script.R
+++ b/script.R
@@ -72,6 +72,9 @@ catnl("Installing required packages...")
 if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", quiet = TRUE)
 }
+if (!requireNamespace("pkgcache", quietly = TRUE)) {
+  install.packages("pkgcache", quiet = TRUE)
+}
 options(
   repos = c(
     PPM = pkgcache::repo_resolve("PPM@latest"),

--- a/script.R
+++ b/script.R
@@ -45,7 +45,7 @@ add_cache_to_minicran <- function(pkg, version, minicran_path) {
 }
 install_and_add_to_minicran <- function(ref, minicran_path) {
   cli::cli_inform(sprintf("Installing and adding %s to miniCRAN...", ref))
-  x <- pak::pkg_install(ref)
+  x <- pak::pkg_install(ref, ask = FALSE)
   for (i in seq_len(nrow(x))) {
     i_package <- x$package[i]
     i_version <- x$version[i]

--- a/script.R
+++ b/script.R
@@ -141,7 +141,7 @@ if (isFALSE(check_if_pkg_available(pkg_name))) {
   pkg_url_gh <- grep("github.com", pkg_url, value = TRUE)
   pkg_ref_released <- paste0(gsub(".*github.com/", "", pkg_url_gh), "@*release")
   if (length(pkg_ref_released) == 0) {
-    cli::cli_abort("Unable to automatically determine the package reference.")
+    cli::cli_abort("Unable to automatically determine the package reference for GitHub release.")
     return(NULL)
   }
   install_and_add_to_minicran(pkg_ref_released, minicran_path)

--- a/script.R
+++ b/script.R
@@ -11,20 +11,20 @@ if_error <- function(x, y = NULL) {
   if (!length(x) || is.null(x)) y else x
 }
 check_if_pkg_available <- function(pkg, ver = NULL) {
-  if (is.null(ver)) {
-    length(available.packages(filters = list(add = TRUE, function(db) db[db[, "Package"] == pkg, ]))) > 0
-  } else {
-    length(
-      available.packages(
-        filters = list(
-          add = TRUE,
-          function(db) {
+  length(
+    available.packages(
+      filters = list(
+        add = TRUE,
+        function(db) {
+          if (is.null(ver)) {
+            db[db[, "Package"] == pkg, ]
+          } else {
             db[db[, "Package"] == pkg & db[, "Version"] == ver, ]
           }
-        )
+        }
       )
-    ) > 0
-  }
+    )
+  ) > 0
 }
 add_to_minicran <- function(x, minicran_path) {
   temp_dir <- tempfile()

--- a/script.R
+++ b/script.R
@@ -12,7 +12,7 @@ if_error <- function(x, y = NULL) {
 }
 check_if_pkg_available <- function(pkg, ver = NULL) {
   if (is.null(ver)) {
-    length(available.packages(filter = list(add = TRUE, function(db) db[db[, "Package"] == pkg, ]))) > 0
+    length(available.packages(filters = list(add = TRUE, function(db) db[db[, "Package"] == pkg, ]))) > 0
   } else {
     length(
       available.packages(

--- a/script.R
+++ b/script.R
@@ -119,15 +119,16 @@ pkg_name <- read.dcf("DESCRIPTION")[, "Package"]
 pkg_ref_released <- if (pkg_name %in% rownames(available.packages())) {
   pkg_name
 } else {
-  # @TODO: think of a better way to get ref for released version of non-CRAN packages
-  read.dcf("DESCRIPTION")[1, "URL"] |>
-    gsub("\n", "", x = _) |>
-    gsub("/$", "", x = _) |>
-    strsplit(x = _, split = ",") |>
-    _[[1]] |>
-    grep(x = _, "github.com", value = TRUE) |>
-    gsub(".*github.com/", "\\1", x = _) |>
-    paste0("@*release")
+  pkg_url <- read.dcf("DESCRIPTION")[1, "URL"]
+  pkg_url_v <- strsplit(pkg_url, ",")[[1]]
+  pkg_url_v <- gsub("\n|/$", "", pkg_url_v)
+  pkg_url_gh <- grep("github.com", pkg_url_v, value = TRUE)
+  res <- paste0(gsub(".*github.com/", "", pkg_url_gh), "@*release")
+  if (length(res) == 0) {
+    cli::cli_abort("Unable to automatically determine the package reference.")
+    return(NULL)
+  }
+  res
 }
 install_and_add_to_minicran(pkg_ref_released, minicran_path)
 cli::cli_progress_step("Installing the package (DEV)...")

--- a/script.R
+++ b/script.R
@@ -15,7 +15,7 @@ check_if_pkg_available <- function(pkg, ver) {
     available.packages(
       filter = list(
         add = TRUE,
-        function (db) {
+        function(db) {
           db[db[, "Package"] == pkg & db[, "Version"] == ver, ]
         }
       )
@@ -23,7 +23,6 @@ check_if_pkg_available <- function(pkg, ver) {
   ) > 0
 }
 install_and_add_to_minicran <- function(pkg, minicran_path) {
-  avail_pkgs <- rownames(available.packages())
   x <- pak::pkg_install(pkg)
   for (i in seq_len(nrow(x))) {
     i_package <- x$package[i]

--- a/script.R
+++ b/script.R
@@ -30,6 +30,7 @@ add_to_minicran <- function(x, minicran_path) {
   temp_dir <- tempfile()
   on.exit(unlink(temp_dir))
   dir.create(temp_dir)
+  # for GH packages we have `pkg_1.2.3.9000_hash.tar.gz` so we need to remove the hash and keep only `pkg_1.2.3.9000.tar.gz`
   new_file_name <- gsub("(.*?_.*)_.*?(\\..*)", "\\1\\2", basename(x))
   file.copy(x, file.path(temp_dir, new_file_name))
   miniCRAN::addLocalPackage(gsub("_.*", "", basename(new_file_name)), temp_dir, minicran_path)

--- a/script.R
+++ b/script.R
@@ -63,10 +63,15 @@ setwd(normalizePath(file.path(args[1])))
 number_of_workers <- as.integer(args[2])
 timeout <- as.integer(args[3])
 
+# debug print - @TODO: remove
+print(.libPaths())
+print(installed.packages()[, c("Package", "LibPath", "Version")])
+
 # Install required packages
 catnl("Installing required packages...")
+options(repos = c(RSPM = "PPM@latest", CRAN = "https://cloud.r-project.org"))
 if (!requireNamespace("pak", quietly = TRUE)) {
-  install.packages("pak")
+  install.packages("pak", quiet = TRUE)
 }
 pak::pkg_install(c(
   "cli",

--- a/script.R
+++ b/script.R
@@ -72,7 +72,12 @@ catnl("Installing required packages...")
 if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", quiet = TRUE)
 }
-options(repos = c(RSPM = "PPM@latest", CRAN = "https://cloud.r-project.org"))
+options(
+  repos = c(
+    PPM = pkgcache::repo_resolve("PPM@latest"),
+    getOption("repos")
+  )
+)
 pak::pkg_install(c(
   "cli",
   "miniCRAN",

--- a/script.R
+++ b/script.R
@@ -16,7 +16,7 @@ check_if_pkg_available <- function(pkg, ver = NULL) {
   } else {
     length(
       available.packages(
-        filter = list(
+        filters = list(
           add = TRUE,
           function(db) {
             db[db[, "Package"] == pkg & db[, "Version"] == ver, ]

--- a/script.R
+++ b/script.R
@@ -65,14 +65,14 @@ timeout <- as.integer(args[3])
 
 # debug print - @TODO: remove
 print(.libPaths())
-print(installed.packages()[, c("Package", "LibPath", "Version")])
+print(installed.packages()[1:3, c("Package", "LibPath", "Version")])
 
 # Install required packages
 catnl("Installing required packages...")
-options(repos = c(RSPM = "PPM@latest", CRAN = "https://cloud.r-project.org"))
 if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak", quiet = TRUE)
 }
+options(repos = c(RSPM = "PPM@latest", CRAN = "https://cloud.r-project.org"))
 pak::pkg_install(c(
   "cli",
   "miniCRAN",

--- a/script.R
+++ b/script.R
@@ -63,10 +63,6 @@ setwd(normalizePath(file.path(args[1])))
 number_of_workers <- as.integer(args[2])
 timeout <- as.integer(args[3])
 
-# debug print - @TODO: remove
-print(.libPaths())
-print(installed.packages()[1:3, c("Package", "LibPath", "Version")])
-
 # Install required packages
 catnl("Installing required packages...")
 if (!requireNamespace("pak", quietly = TRUE)) {


### PR DESCRIPTION
alternative to: https://github.com/insightsengineering/r-revdepcheck-action/pull/3

test those two together:
- https://github.com/insightsengineering/r.pkg.template/pull/255
- https://github.com/insightsengineering/r-revdepcheck-action/pull/4

This would require additional inputs: `lookup-refs` action parameter. I think that this is ok since we have to have an information where to find non-cran dependencies. The Remotes field (if provided) will be used instead of this. 
See: https://github.com/insightsengineering/teal.goshawk/compare/main...refs/heads/fix_non_cran2 as an example

Tests:
- https://github.com/insightsengineering/teal.goshawk/actions/workflows/scheduled.yaml?query=branch%3Afix_non_cran2
- https://github.com/insightsengineering/teal.osprey/actions/workflows/scheduled.yaml?query=branch%3Afix_non_cran2