### PR TITLE
refactor - use `pak` for downloading and installing

### DIFF
--- a/script.R
+++ b/script.R
@@ -103,6 +103,9 @@ get_tar_gz_from_fulltarget_tree <- function(pkg, version, path) {
     )
   } else {
     untarred_dir <- tempfile()
+    # this is a private function that handle different compression mechanism
+    # local runs use `tar` but `zip` on remote
+    # this function nicely handles both
     px <- pkgdepends:::make_uncompress_process(path, untarred_dir)
     px$wait()
     sources_dirs <- list.dirs(
@@ -445,4 +448,10 @@ if (
   )
 ) {
   stop("There are errors. Please refer to the logs above.")
+}
+
+if (
+  !all(vapply(revdepcheck::revdep_summary(), `[[`, character(1), "status") == "+")
+) {
+  stop("There are failures. Please refer to the logs above.")
 }

--- a/script.R
+++ b/script.R
@@ -103,7 +103,7 @@ get_tar_gz_from_fulltarget_tree <- function(pkg, version, path) {
     )
   } else {
     untarred_dir <- tempfile()
-    untar(path, exdir = untarred_dir)
+    untar(normalizePath(path), exdir = untarred_dir)
     sources_dirs <- list.dirs(
       untarred_dir,
       full.names = TRUE,
@@ -156,10 +156,7 @@ download_and_add_to_minicran <- function(ref, minicran_path) {
         x[i, "fulltarget"]
       )
     } else if (file.exists(x[i, "fulltarget_tree"])) {
-      cli::cli_inform(sprintf(
-        "Using fulltarget_tree path: %s",
-        x[i, "fulltarget_tree"]
-      ))
+      cli::cli_inform(sprintf("Using fulltarget_tree path: %s", x[i, "fulltarget_tree"]))
       tar_gz_path <- get_tar_gz_from_fulltarget_tree(
         x[i, "package"],
         x[i, "version"],

--- a/script.R
+++ b/script.R
@@ -37,7 +37,9 @@ check_if_pkg_available <- function(pkg, ver = NULL) {
   }
 }
 check_if_added <- function(pkg, ver = NULL, minicran_path) {
-  minicran_ap <- as.data.frame(available.packages(repos = paste0("file:///", minicran_path)))
+  minicran_ap <- as.data.frame(available.packages(
+    repos = paste0("file:///", minicran_path)
+  ))
   if (nrow(minicran_ap) == 0) return(FALSE)
   if (is.null(ver)) {
     nrow(subset(minicran_ap, Package == pkg)) > 0
@@ -48,7 +50,9 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
 get_tar_gz <- function(pkg, version, path) {
   # Check file extension first and return early if not supported
   if (!grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
-    cli::cli_abort("Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file.")
+    cli::cli_abort(
+      "Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file."
+    )
   }
 
   # Check if file/directory exists
@@ -77,7 +81,13 @@ get_tar_gz <- function(pkg, version, path) {
       }
       temp_dir <- tempfile()
       dir.create(temp_dir)
-      built_path <- pkgbuild::build(pkg_path, dest_path = temp_dir, binary = FALSE, manual = FALSE, vignettes = FALSE)
+      built_path <- pkgbuild::build(
+        pkg_path,
+        dest_path = temp_dir,
+        binary = FALSE,
+        manual = FALSE,
+        vignettes = FALSE
+      )
       return(built_path)
     } else {
       # It's a file with .tar.gz-t extension
@@ -87,33 +97,57 @@ get_tar_gz <- function(pkg, version, path) {
         # This is a local package - build directly without untarring
         temp_dir <- tempfile()
         dir.create(temp_dir)
-        built_path <- pkgbuild::build(pkg_path, dest_path = temp_dir, binary = FALSE, manual = FALSE, vignettes = FALSE)
+        built_path <- pkgbuild::build(
+          pkg_path,
+          dest_path = temp_dir,
+          binary = FALSE,
+          manual = FALSE,
+          vignettes = FALSE
+        )
         return(built_path)
       } else {
         # This might be a GitHub package that needs untarring
         untarred_dir <- tempfile()
         untar_result <- try(untar(path, exdir = untarred_dir), silent = TRUE)
         if (inherits(untar_result, "try-error")) {
-          cli::cli_warn("Failed to extract {path} and no local package directory found, skipping...")
+          cli::cli_warn(
+            "Failed to extract {path} and no local package directory found, skipping..."
+          )
           return(NULL)
         }
 
-        sources_dirs <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
+        sources_dirs <- list.dirs(
+          untarred_dir,
+          full.names = TRUE,
+          recursive = FALSE
+        )
         if (length(sources_dirs) == 0) {
-          cli::cli_warn("No directories found after extracting {path}, skipping...")
+          cli::cli_warn(
+            "No directories found after extracting {path}, skipping..."
+          )
           return(NULL)
         }
 
         temp_dir <- tempfile()
         dir.create(temp_dir)
-        built_path <- pkgbuild::build(sources_dirs[1], dest_path = temp_dir, binary = FALSE, manual = FALSE, vignettes = FALSE)
+        built_path <- pkgbuild::build(
+          sources_dirs[1],
+          dest_path = temp_dir,
+          binary = FALSE,
+          manual = FALSE,
+          vignettes = FALSE
+        )
         return(built_path)
       }
     }
   }
 }
 get_tar_gz_from_cache <- function(pkg, version) {
-  i_cache <- pkgcache::pkg_cache_find(package = pkg, version = version, platform = "source") %df_empty%
+  i_cache <- pkgcache::pkg_cache_find(
+    package = pkg,
+    version = version,
+    platform = "source"
+  ) %df_empty%
     pkgcache::pkg_cache_find(package = pkg, version = version)
 
   if (nrow(i_cache) == 0) return(NULL)
@@ -138,8 +172,18 @@ add_to_minicran <- function(pkg, version, tar_gz_path, minicran_path) {
 
   invisible(NULL)
 }
-build_and_add_to_minicran <- function(pkg, version, fulltarget, fulltarget_tree, minicran_path) {
-  cli::cli_inform(sprintf("Building and adding %s version %s to miniCRAN...", pkg, version))
+build_and_add_to_minicran <- function(
+  pkg,
+  version,
+  fulltarget,
+  fulltarget_tree,
+  minicran_path
+) {
+  cli::cli_inform(sprintf(
+    "Building and adding %s version %s to miniCRAN...",
+    pkg,
+    version
+  ))
 
   tgz_path <- NULL
 
@@ -163,7 +207,9 @@ build_and_add_to_minicran <- function(pkg, version, fulltarget, fulltarget_tree,
   }
 
   if (is.null(tgz_path)) {
-    cli::cli_warn("Failed to get tar.gz file for {pkg} version {version}, skipping...")
+    cli::cli_warn(
+      "Failed to get tar.gz file for {pkg} version {version}, skipping..."
+    )
     return(invisible(NULL))
   }
 
@@ -233,15 +279,18 @@ if (!requireNamespace("pak", quietly = TRUE)) {
 if (!requireNamespace("pkgcache", quietly = TRUE)) {
   install.packages("pkgcache", quiet = TRUE)
 }
-pak::pkg_install(c(
-  "cli",
-  "miniCRAN",
-  "pkgbuild",
-  "pkgdepends",
-  "r-lib/revdepcheck",
-  "usethis",
-  "yaml"
-), ask = FALSE)
+pak::pkg_install(
+  c(
+    "cli",
+    "miniCRAN",
+    "pkgbuild",
+    "pkgdepends",
+    "r-lib/revdepcheck",
+    "usethis",
+    "yaml"
+  ),
+  ask = FALSE
+)
 options(
   repos = c(
     PPM = pkgcache::repo_resolve("PPM@latest"),
@@ -285,13 +334,20 @@ minicran_path <- tempfile()
 dir.create(minicran_path)
 on.exit(unlink(minicran_path, recursive = TRUE), add = TRUE)
 # added `rlang` as a dummy package as the `pkgs` arg cannot be empty
-miniCRAN::makeRepo(pkgs = "rlang", path = minicran_path, type = c("source", .Platform$pkgType), quiet = TRUE)
+miniCRAN::makeRepo(
+  pkgs = "rlang",
+  path = minicran_path,
+  type = c("source", .Platform$pkgType),
+  quiet = TRUE
+)
 # add minicran repo path to repos so that revdepcheck can use it
 # this is the directory where we will store packages from config file
-options("repos" = c(
-  "minicran" = paste0("file:///", minicran_path),
-  getOption("repos")
-))
+options(
+  "repos" = c(
+    "minicran" = paste0("file:///", minicran_path),
+    getOption("repos")
+  )
+)
 #Sys.setenv(CRANCACHE_REPOS = "minicran, cran, bioc")
 
 ## installing the package
@@ -302,11 +358,17 @@ if (check_if_pkg_available(pkg_name)) {
   pkg_ref_released <- pkg_name
 } else {
   # try to get the package reference from the DESCRIPTION file (URL field)
-  pkg_url <- gsub("\n|/$", "", strsplit(read.dcf("DESCRIPTION")[1, "URL"], ",")[[1]])
+  pkg_url <- gsub(
+    "\n|/$",
+    "",
+    strsplit(read.dcf("DESCRIPTION")[1, "URL"], ",")[[1]]
+  )
   pkg_url_gh <- grep("github.com", pkg_url, value = TRUE)
   pkg_ref_released <- paste0(gsub(".*github.com/", "", pkg_url_gh), "@*release")
   if (length(pkg_ref_released) == 0) {
-    cli::cli_abort("Unable to automatically determine the package reference for GitHub release.")
+    cli::cli_abort(
+      "Unable to automatically determine the package reference for GitHub release."
+    )
     return(NULL)
   }
 }
@@ -335,23 +397,32 @@ cli::cli_progress_bar("Adding refs to revdepcheck", total = length(refs))
 for (ref in refs) {
   cli::cli_progress_message("Adding {ref}...")
 
-  tryCatch({
-    download_and_add_to_minicran(ref, minicran_path)
+  tryCatch(
+    {
+      install_and_add_to_minicran(ref, minicran_path)
 
-    ref_pkg <- pkgdepends::parse_pkg_ref(ref)$package
-    revdepcheck::revdep_add(packages = ref_pkg)
+      ref_pkg <- pkgdepends::parse_pkg_ref(ref)$package
+      revdepcheck::revdep_add(packages = ref_pkg)
 
-    cli::cli_inform("Added {ref} to revdep todo!")
-  }, error = function(e) {
-    cli::cli_warn(sprintf("Failed to download and add %s to miniCRAN: %s", ref, e$message))
-  })
+      cli::cli_inform("Added {ref} to revdep todo!")
+    },
+    error = function(e) {
+      cli::cli_warn(sprintf(
+        "Failed to download and add %s to miniCRAN: %s",
+        ref,
+        e$message
+      ))
+    }
+  )
 
   cli::cli_progress_update()
 }
 cli::cli_progress_done()
 cli::cli_inform("All references added!")
 
-cli::cli_inform("The current revdep todo (empty indicates the default - all revdeps):")
+cli::cli_inform(
+  "The current revdep todo (empty indicates the default - all revdeps):"
+)
 print(revdepcheck::revdep_todo())
 
 
@@ -361,7 +432,11 @@ miniCRAN::pkgAvail(repos = minicran_path)[, c("Package", "Version")]
 
 # Execute
 cli::cli_h1("Execute revdepcheck")
-revdepcheck::revdep_check(num_workers = number_of_workers, timeout = timeout, quiet = FALSE)
+revdepcheck::revdep_check(
+  num_workers = number_of_workers,
+  timeout = timeout,
+  quiet = FALSE
+)
 
 
 # Print results
@@ -395,7 +470,12 @@ if (length(revdepcheck::revdep_summary())) {
         rbind.data.frame,
         lapply(
           revdepcheck::revdep_summary(),
-          function(i) c(i$package, if_error(i$old[[1]]$duration) %||% "?", if_error(i$new$duration) %||% "?")
+          function(i)
+            c(
+              i$package,
+              if_error(i$old[[1]]$duration) %||% "?",
+              if_error(i$new$duration) %||% "?"
+            )
         )
       ),
       c("package", "old", "new")
@@ -405,6 +485,11 @@ if (length(revdepcheck::revdep_summary())) {
   print("(empty)")
 }
 
-if (!identical(readLines("revdep/problems.md", warn = FALSE), "*Wow, no problems at all. :)*")) {
+if (
+  !identical(
+    readLines("revdep/problems.md", warn = FALSE),
+    "*Wow, no problems at all. :)*"
+  )
+) {
   stop("There are errors. Please refer to the logs above.")
 }

--- a/script.R
+++ b/script.R
@@ -40,7 +40,9 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
   minicran_ap <- as.data.frame(available.packages(
     repos = paste0("file:///", minicran_path)
   ))
-  if (nrow(minicran_ap) == 0) return(FALSE)
+  if (nrow(minicran_ap) == 0) {
+    return(FALSE)
+  }
   if (is.null(ver)) {
     nrow(subset(minicran_ap, Package == pkg)) > 0
   } else {
@@ -48,6 +50,8 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
   }
 }
 get_tar_gz <- function(pkg, version, path) {
+  cli::cli_inform("DEBUG: get_tar_gz called for {pkg} version {version} with path {path}")
+
   # Check file extension first and return early if not supported
   if (!grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
     cli::cli_abort(
@@ -63,6 +67,7 @@ get_tar_gz <- function(pkg, version, path) {
 
   if (grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
     # Regular .tar.gz file - validate it's a proper tar archive
+    cli::cli_inform("DEBUG: Processing regular .tar.gz file: {path}")
     res <- try(untar(path, list = TRUE), silent = TRUE)
     if (inherits(res, "try-error")) {
       cli::cli_abort("File {path} is not a valid tar archive.")
@@ -70,14 +75,19 @@ get_tar_gz <- function(pkg, version, path) {
     return(path)
   } else if (grepl(".*.tar.gz-t$", path)) {
     # Handle .tar.gz-t files - these are pak's local package cache
-    # Key insight: For local packages, don't untar! The path is already a directory structure
+    cli::cli_inform("DEBUG: Processing .tar.gz-t file/directory: {path}")
 
+    # Key insight: For local packages, don't untar! The path is already a directory structure
     if (file.info(path)$isdir) {
       # It's a directory - build directly from it
+      cli::cli_inform("DEBUG: Path is a directory, building package from it")
       pkg_path <- file.path(path, pkg)
       if (!dir.exists(pkg_path)) {
         # If pkg subdirectory doesn't exist, use the directory itself
+        cli::cli_inform("DEBUG: Subdirectory {pkg_path} not found, using {path} directly")
         pkg_path <- path
+      } else {
+        cli::cli_inform("DEBUG: Using subdirectory {pkg_path}")
       }
       temp_dir <- tempfile()
       dir.create(temp_dir)
@@ -91,10 +101,12 @@ get_tar_gz <- function(pkg, version, path) {
       return(built_path)
     } else {
       # It's a file with .tar.gz-t extension
+      cli::cli_inform("DEBUG: Path is a file with .tar.gz-t extension")
       # For local packages: DON'T untar, build directly from the path structure
       pkg_path <- file.path(path, pkg)
       if (dir.exists(pkg_path)) {
         # This is a local package - build directly without untarring
+        cli::cli_inform("DEBUG: Local package directory found at {pkg_path}")
         temp_dir <- tempfile()
         dir.create(temp_dir)
         built_path <- pkgbuild::build(
@@ -107,12 +119,26 @@ get_tar_gz <- function(pkg, version, path) {
         return(built_path)
       } else {
         # This might be a GitHub package that needs untarring
+        cli::cli_inform("DEBUG: No local package directory found, attempting to untar")
+
+        # Debug print of untar list before extraction
+        cli::cli_inform("DEBUG: Listing contents of tar file before extraction")
+        tar_contents <- try(untar(path, list = TRUE), silent = TRUE)
+        if (inherits(tar_contents, "try-error")) {
+          cli::cli_warn("DEBUG: Failed to list contents: {attr(tar_contents, 'condition')$message}")
+        } else {
+          cli::cli_inform("DEBUG: Tar contents (first 10 entries):")
+          cli::cli_inform(paste(utils::head(tar_contents, 10), collapse = "\n"))
+        }
+
         untarred_dir <- tempfile()
+        cli::cli_inform("DEBUG: Untarring to {untarred_dir}")
         untar_result <- try(untar(path, exdir = untarred_dir), silent = TRUE)
         if (inherits(untar_result, "try-error")) {
           cli::cli_warn(
             "Failed to extract {path} and no local package directory found, skipping..."
           )
+          cli::cli_inform("DEBUG: Untar error: {attr(untar_result, 'condition')$message}")
           return(NULL)
         }
 
@@ -121,6 +147,11 @@ get_tar_gz <- function(pkg, version, path) {
           full.names = TRUE,
           recursive = FALSE
         )
+        cli::cli_inform("DEBUG: Found {length(sources_dirs)} source directories after extraction")
+        if (length(sources_dirs) > 0) {
+          cli::cli_inform("DEBUG: Directories: {paste(sources_dirs, collapse=', ')}")
+        }
+
         if (length(sources_dirs) == 0) {
           cli::cli_warn(
             "No directories found after extracting {path}, skipping..."
@@ -130,6 +161,7 @@ get_tar_gz <- function(pkg, version, path) {
 
         temp_dir <- tempfile()
         dir.create(temp_dir)
+        cli::cli_inform("DEBUG: Building package from {sources_dirs[1]}")
         built_path <- pkgbuild::build(
           sources_dirs[1],
           dest_path = temp_dir,
@@ -150,7 +182,9 @@ get_tar_gz_from_cache <- function(pkg, version) {
   ) %df_empty%
     pkgcache::pkg_cache_find(package = pkg, version = version)
 
-  if (nrow(i_cache) == 0) return(NULL)
+  if (nrow(i_cache) == 0) {
+    return(NULL)
+  }
 
   get_tar_gz(pkg, version, i_cache$fullpath[[1]])
 }
@@ -470,12 +504,13 @@ if (length(revdepcheck::revdep_summary())) {
         rbind.data.frame,
         lapply(
           revdepcheck::revdep_summary(),
-          function(i)
+          function(i) {
             c(
               i$package,
               if_error(i$old[[1]]$duration) %||% "?",
               if_error(i$new$duration) %||% "?"
             )
+          }
         )
       ),
       c("package", "old", "new")

--- a/script.R
+++ b/script.R
@@ -28,9 +28,9 @@ if_error <- function(x, y = NULL) {
 available_packages <- as.data.frame(available.packages())
 check_if_pkg_available <- function(pkg, ver = NULL) {
   if (is.null(ver)) {
-    nrow(subset(available_packages, Package == pkg)) > 0
+    nrow(subset(available_packages, Package == pkg)) > 0 # nolint object_usage_linter.
   } else {
-    nrow(subset(available_packages, Package == pkg & Version >= ver)) > 0
+    nrow(subset(available_packages, Package == pkg & Version >= ver)) > 0 # nolint object_usage_linter.
   }
 }
 check_if_added <- function(pkg, ver = NULL, minicran_path) {
@@ -41,9 +41,9 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
     return(FALSE)
   }
   if (is.null(ver)) {
-    nrow(subset(minicran_ap, Package == pkg)) > 0
+    nrow(subset(minicran_ap, Package == pkg)) > 0 # nolint object_usage_linter.
   } else {
-    nrow(subset(minicran_ap, Package == pkg & Version == ver)) > 0
+    nrow(subset(minicran_ap, Package == pkg & Version == ver)) > 0 # nolint object_usage_linter.
   }
 }
 add_to_minicran <- function(pkg, version, tar_gz_path, minicran_path) {

--- a/script.R
+++ b/script.R
@@ -46,46 +46,69 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
   }
 }
 get_tar_gz <- function(pkg, version, path) {
+  # Check file extension first and return early if not supported
   if (!grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
     cli::cli_abort("Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file.")
   }
 
+  # Check if file/directory exists
   if (!file.exists(path)) {
     cli::cli_warn("Path {path} does not exist, skipping...")
     return(NULL)
   }
 
-  is_valid_tar_gz <- function(file) {
-    if (grepl(".*.tar.gz-t$", file)) {
-      return(TRUE)
-    }
-    res <- try(untar(file, list = TRUE), silent = TRUE)
-    !inherits(res, "try-error")
-  }
-
   if (grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
-    if (!is_valid_tar_gz(path)) {
+    # Regular .tar.gz file - validate it's a proper tar archive
+    res <- try(untar(path, list = TRUE), silent = TRUE)
+    if (inherits(res, "try-error")) {
       cli::cli_abort("File {path} is not a valid tar archive.")
     }
     return(path)
   } else if (grepl(".*.tar.gz-t$", path)) {
-    tgz_path <- tempfile(fileext = ".tar.gz")
+    # Handle .tar.gz-t files - these are pak's local package cache
+    # Key insight: For local packages, don't untar! The path is already a directory structure
 
     if (file.info(path)$isdir) {
-      pkgbuild::build(file.path(path, pkg), dest_path = tgz_path, binary = FALSE, manual = FALSE, vignettes = FALSE)
-      return(tgz_path)
-    } else {
-      untarred_dir <- tempfile()
-      dir.create(untarred_dir)
-      on.exit(unlink(untarred_dir, recursive = TRUE), add = TRUE)
-
-      if (!is_valid_tar_gz(path)) {
-        cli::cli_abort("File {path} is not a valid tar archive.")
+      # It's a directory - build directly from it
+      pkg_path <- file.path(path, pkg)
+      if (!dir.exists(pkg_path)) {
+        # If pkg subdirectory doesn't exist, use the directory itself
+        pkg_path <- path
       }
-      untar(path, exdir = untarred_dir)
-      sources_dirs <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
-      pkgbuild::build(sources_dirs[1], dest_path = tgz_path, binary = FALSE, manual = FALSE, vignettes = FALSE)
-      return(tgz_path)
+      temp_dir <- tempfile()
+      dir.create(temp_dir)
+      built_path <- pkgbuild::build(pkg_path, dest_path = temp_dir, binary = FALSE, manual = FALSE, vignettes = FALSE)
+      return(built_path)
+    } else {
+      # It's a file with .tar.gz-t extension
+      # For local packages: DON'T untar, build directly from the path structure
+      pkg_path <- file.path(path, pkg)
+      if (dir.exists(pkg_path)) {
+        # This is a local package - build directly without untarring
+        temp_dir <- tempfile()
+        dir.create(temp_dir)
+        built_path <- pkgbuild::build(pkg_path, dest_path = temp_dir, binary = FALSE, manual = FALSE, vignettes = FALSE)
+        return(built_path)
+      } else {
+        # This might be a GitHub package that needs untarring
+        untarred_dir <- tempfile()
+        untar_result <- try(untar(path, exdir = untarred_dir), silent = TRUE)
+        if (inherits(untar_result, "try-error")) {
+          cli::cli_warn("Failed to extract {path} and no local package directory found, skipping...")
+          return(NULL)
+        }
+
+        sources_dirs <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
+        if (length(sources_dirs) == 0) {
+          cli::cli_warn("No directories found after extracting {path}, skipping...")
+          return(NULL)
+        }
+
+        temp_dir <- tempfile()
+        dir.create(temp_dir)
+        built_path <- pkgbuild::build(sources_dirs[1], dest_path = temp_dir, binary = FALSE, manual = FALSE, vignettes = FALSE)
+        return(built_path)
+      }
     }
   }
 }
@@ -120,12 +143,23 @@ build_and_add_to_minicran <- function(pkg, version, fulltarget, fulltarget_tree,
 
   tgz_path <- NULL
 
+  cli::cli_inform("Debugging package: {pkg} version {version}")
+  cli::cli_inform("- checking fulltarget: {fulltarget}")
+  cli::cli_inform("- fulltarget exists: {file.exists(fulltarget)}")
+  cli::cli_inform("- checking fulltarget_tree: {fulltarget_tree}")
+  cli::cli_inform("- fulltarget_tree exists: {file.exists(fulltarget_tree)}")
+
   if (file.exists(fulltarget)) {
     tgz_path <- fulltarget
+    cli::cli_inform("- using fulltarget path: {tgz_path}")
   } else if (file.exists(fulltarget_tree)) {
+    cli::cli_inform("- attempting to extract from fulltarget_tree")
     tgz_path <- get_tar_gz(pkg, version, fulltarget_tree)
+    cli::cli_inform("- extracted tgz_path: {tgz_path %||% 'NULL'}")
   } else {
+    cli::cli_inform("- attempting to find package in cache")
     tgz_path <- get_tar_gz_from_cache(pkg, version)
+    cli::cli_inform("- cache tgz_path: {tgz_path %||% 'NULL'}")
   }
 
   if (is.null(tgz_path)) {

--- a/script.R
+++ b/script.R
@@ -359,7 +359,7 @@ for (ref in refs) {
 
   tryCatch(
     {
-      install_and_add_to_minicran(ref, minicran_path)
+      download_and_add_to_minicran(ref, minicran_path)
 
       ref_pkg <- pkgdepends::parse_pkg_ref(ref)$package
       revdepcheck::revdep_add(packages = ref_pkg)

--- a/script.R
+++ b/script.R
@@ -46,35 +46,47 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
   }
 }
 get_tar_gz <- function(pkg, version, path) {
+  if (!grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
+    cli::cli_abort("Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file.")
+  }
+
+  if (!file.exists(path)) {
+    cli::cli_warn("Path {path} does not exist, skipping...")
+    return(NULL)
+  }
+
   is_valid_tar_gz <- function(file) {
+    if (grepl(".*.tar.gz-t$", file)) {
+      return(TRUE)
+    }
     res <- try(untar(file, list = TRUE), silent = TRUE)
     !inherits(res, "try-error")
   }
-  if (grepl(".*.tar.gz$", path)) {
-    # Check if the file is a valid tar archive
+
+  if (grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
     if (!is_valid_tar_gz(path)) {
       cli::cli_abort("File {path} is not a valid tar archive.")
     }
-    path
+    return(path)
   } else if (grepl(".*.tar.gz-t$", path)) {
     tgz_path <- tempfile(fileext = ".tar.gz")
+
     if (file.info(path)$isdir) {
-      pkgbuild::build(file.path(path, pkg), binary = FALSE, manual = FALSE, vignettes = FALSE, dest_path = tgz_path)
+      pkgbuild::build(file.path(path, pkg), dest_path = tgz_path, binary = FALSE, manual = FALSE, vignettes = FALSE)
+      return(tgz_path)
     } else {
       untarred_dir <- tempfile()
       dir.create(untarred_dir)
       on.exit(unlink(untarred_dir, recursive = TRUE), add = TRUE)
-      # Check if the file is a valid tar archive before untarring
+
       if (!is_valid_tar_gz(path)) {
         cli::cli_abort("File {path} is not a valid tar archive.")
       }
       untar(path, exdir = untarred_dir)
-      sources_dir <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
-      pkgbuild::build(sources_dir, binary = FALSE, manual = FALSE, vignettes = FALSE, dest_path = tgz_path)
-      tgz_path
+      sources_dirs <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
+      pkgbuild::build(sources_dirs[1], dest_path = tgz_path, binary = FALSE, manual = FALSE, vignettes = FALSE)
+      return(tgz_path)
     }
-  } else {
-    cli::cli_abort("Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file.")
   }
 }
 get_tar_gz_from_cache <- function(pkg, version) {
@@ -106,15 +118,19 @@ add_to_minicran <- function(pkg, version, tar_gz_path, minicran_path) {
 build_and_add_to_minicran <- function(pkg, version, fulltarget, fulltarget_tree, minicran_path) {
   cli::cli_inform(sprintf("Building and adding %s version %s to miniCRAN...", pkg, version))
 
+  tgz_path <- NULL
+
   if (file.exists(fulltarget)) {
     tgz_path <- fulltarget
   } else if (file.exists(fulltarget_tree)) {
     tgz_path <- get_tar_gz(pkg, version, fulltarget_tree)
   } else {
     tgz_path <- get_tar_gz_from_cache(pkg, version)
-    if (is.null(tgz_path)) {
-      return(invisible(NULL))
-    }
+  }
+
+  if (is.null(tgz_path)) {
+    cli::cli_warn("Failed to get tar.gz file for {pkg} version {version}, skipping...")
+    return(invisible(NULL))
   }
 
   add_to_minicran(pkg, version, tgz_path, minicran_path)

--- a/script.R
+++ b/script.R
@@ -103,7 +103,8 @@ get_tar_gz_from_fulltarget_tree <- function(pkg, version, path) {
     )
   } else {
     untarred_dir <- tempfile()
-    untar(normalizePath(path), exdir = untarred_dir)
+    px <- pkgdepends:::make_uncompress_process(path, untarred_dir)
+    px$wait()
     sources_dirs <- list.dirs(
       untarred_dir,
       full.names = TRUE,

--- a/script.R
+++ b/script.R
@@ -25,9 +25,6 @@ if_error <- function(x, y = NULL) {
 `%||%` <- function(x, y) {
   if (!length(x) || is.null(x)) y else x
 }
-`%df_empty%` <- function(x, y) {
-  if (is.data.frame(x) && nrow(x) == 0) y else x
-}
 available_packages <- as.data.frame(available.packages())
 check_if_pkg_available <- function(pkg, ver = NULL) {
   if (is.null(ver)) {
@@ -49,145 +46,6 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
     nrow(subset(minicran_ap, Package == pkg & Version == ver)) > 0
   }
 }
-get_tar_gz <- function(pkg, version, path) {
-  cli::cli_inform("DEBUG: get_tar_gz called for {pkg} version {version} with path {path}")
-
-  # Check file extension first and return early if not supported
-  if (!grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
-    cli::cli_abort(
-      "Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file."
-    )
-  }
-
-  # Check if file/directory exists
-  if (!file.exists(path)) {
-    cli::cli_warn("Path {path} does not exist, skipping...")
-    return(NULL)
-  }
-
-  if (grepl(".*.tar.gz$", path) && !grepl(".*.tar.gz-t$", path)) {
-    # Regular .tar.gz file - validate it's a proper tar archive
-    cli::cli_inform("DEBUG: Processing regular .tar.gz file: {path}")
-    res <- try(untar(path, list = TRUE), silent = TRUE)
-    if (inherits(res, "try-error")) {
-      cli::cli_abort("File {path} is not a valid tar archive.")
-    }
-    return(path)
-  } else if (grepl(".*.tar.gz-t$", path)) {
-    # Handle .tar.gz-t files - these are pak's local package cache
-    cli::cli_inform("DEBUG: Processing .tar.gz-t file/directory: {path}")
-
-    # Key insight: For local packages, don't untar! The path is already a directory structure
-    if (file.info(path)$isdir) {
-      # It's a directory - build directly from it
-      cli::cli_inform("DEBUG: Path is a directory, building package from it")
-      pkg_path <- file.path(path, pkg)
-      if (!dir.exists(pkg_path)) {
-        # If pkg subdirectory doesn't exist, use the directory itself
-        cli::cli_inform("DEBUG: Subdirectory {pkg_path} not found, using {path} directly")
-        pkg_path <- path
-      } else {
-        cli::cli_inform("DEBUG: Using subdirectory {pkg_path}")
-      }
-      temp_dir <- tempfile()
-      dir.create(temp_dir)
-      built_path <- pkgbuild::build(
-        pkg_path,
-        dest_path = temp_dir,
-        binary = FALSE,
-        manual = FALSE,
-        vignettes = FALSE
-      )
-      return(built_path)
-    } else {
-      # It's a file with .tar.gz-t extension
-      cli::cli_inform("DEBUG: Path is a file with .tar.gz-t extension")
-      # For local packages: DON'T untar, build directly from the path structure
-      pkg_path <- file.path(path, pkg)
-      if (dir.exists(pkg_path)) {
-        # This is a local package - build directly without untarring
-        cli::cli_inform("DEBUG: Local package directory found at {pkg_path}")
-        temp_dir <- tempfile()
-        dir.create(temp_dir)
-        built_path <- pkgbuild::build(
-          pkg_path,
-          dest_path = temp_dir,
-          binary = FALSE,
-          manual = FALSE,
-          vignettes = FALSE
-        )
-        return(built_path)
-      } else {
-        # This might be a GitHub package that needs untarring
-        cli::cli_inform("DEBUG: No local package directory found, attempting to untar")
-
-        # Debug print of untar list before extraction
-        cli::cli_inform("DEBUG: Listing contents of tar file before extraction")
-        tar_contents <- try(untar(path, list = TRUE), silent = TRUE)
-        if (inherits(tar_contents, "try-error")) {
-          cli::cli_warn("DEBUG: Failed to list contents: {attr(tar_contents, 'condition')$message}")
-        } else {
-          cli::cli_inform("DEBUG: Tar contents (first 10 entries):")
-          cli::cli_inform(paste(utils::head(tar_contents, 10), collapse = "\n"))
-        }
-
-        untarred_dir <- tempfile()
-        cli::cli_inform("DEBUG: Untarring to {untarred_dir}")
-        untar_result <- try(untar(path, exdir = untarred_dir), silent = TRUE)
-        if (inherits(untar_result, "try-error")) {
-          cli::cli_warn(
-            "Failed to extract {path} and no local package directory found, skipping..."
-          )
-          cli::cli_inform("DEBUG: Untar error: {attr(untar_result, 'condition')$message}")
-          return(NULL)
-        }
-
-        sources_dirs <- list.dirs(
-          untarred_dir,
-          full.names = TRUE,
-          recursive = FALSE
-        )
-        cli::cli_inform("DEBUG: Found {length(sources_dirs)} source directories after extraction")
-        if (length(sources_dirs) > 0) {
-          cli::cli_inform("DEBUG: Directories: {paste(sources_dirs, collapse=', ')}")
-        }
-
-        if (length(sources_dirs) == 0) {
-          cli::cli_warn(
-            "No directories found after extracting {path}, skipping..."
-          )
-          return(NULL)
-        }
-
-        temp_dir <- tempfile()
-        dir.create(temp_dir)
-        cli::cli_inform("DEBUG: Building package from {sources_dirs[1]}")
-        built_path <- pkgbuild::build(
-          sources_dirs[1],
-          dest_path = temp_dir,
-          binary = FALSE,
-          manual = FALSE,
-          vignettes = FALSE
-        )
-        return(built_path)
-      }
-    }
-  }
-}
-get_tar_gz_from_cache <- function(pkg, version) {
-  i_cache <- pkgcache::pkg_cache_find(
-    package = pkg,
-    version = version,
-    platform = "source"
-  ) %df_empty%
-    pkgcache::pkg_cache_find(package = pkg, version = version)
-
-  if (nrow(i_cache) == 0) {
-    return(NULL)
-  }
-
-  get_tar_gz(pkg, version, i_cache$fullpath[[1]])
-}
 add_to_minicran <- function(pkg, version, tar_gz_path, minicran_path) {
   cli::cli_inform(sprintf("Adding %s version %s to miniCRAN...", pkg, version))
 
@@ -206,50 +64,67 @@ add_to_minicran <- function(pkg, version, tar_gz_path, minicran_path) {
 
   invisible(NULL)
 }
-build_and_add_to_minicran <- function(
-  pkg,
-  version,
-  fulltarget,
-  fulltarget_tree,
-  minicran_path
-) {
-  cli::cli_inform(sprintf(
-    "Building and adding %s version %s to miniCRAN...",
-    pkg,
-    version
-  ))
+get_tar_gz_from_installed <- function(pkg) {
+  tempdir <- tempfile()
+  dir.create(tempdir)
+  withr::with_dir(tempdir, normalizePath(pkgdepends::pkg_build(pkg)))
+}
+get_tar_gz_from_cache <- function(pkg, version) {
+  i_cache <- pkgcache::pkg_cache_find(
+    package = pkg,
+    version = version,
+    platform = "source"
+  )
 
-  tgz_path <- NULL
-
-  cli::cli_inform("Debugging package: {pkg} version {version}")
-  cli::cli_inform("- checking fulltarget: {fulltarget}")
-  cli::cli_inform("- fulltarget exists: {file.exists(fulltarget)}")
-  cli::cli_inform("- checking fulltarget_tree: {fulltarget_tree}")
-  cli::cli_inform("- fulltarget_tree exists: {file.exists(fulltarget_tree)}")
-
-  if (file.exists(fulltarget)) {
-    tgz_path <- fulltarget
-    cli::cli_inform("- using fulltarget path: {tgz_path}")
-  } else if (file.exists(fulltarget_tree)) {
-    cli::cli_inform("- attempting to extract from fulltarget_tree")
-    tgz_path <- get_tar_gz(pkg, version, fulltarget_tree)
-    cli::cli_inform("- extracted tgz_path: {tgz_path %||% 'NULL'}")
-  } else {
-    cli::cli_inform("- attempting to find package in cache")
-    tgz_path <- get_tar_gz_from_cache(pkg, version)
-    cli::cli_inform("- cache tgz_path: {tgz_path %||% 'NULL'}")
-  }
-
-  if (is.null(tgz_path)) {
-    cli::cli_warn(
-      "Failed to get tar.gz file for {pkg} version {version}, skipping..."
+  if (nrow(i_cache) == 0) {
+    i_cache <- pkgcache::pkg_cache_find(
+      package = pkg,
+      version = version
     )
-    return(invisible(NULL))
   }
 
-  add_to_minicran(pkg, version, tgz_path, minicran_path)
+  if (nrow(i_cache) == 0) {
+    return(NULL)
+  }
 
-  invisible(NULL)
+  i_cache$fullpath[[1]]
+}
+get_tar_gz_from_file <- function(pkg, version, path) {
+  path
+}
+get_tar_gz_from_fulltarget <- function(pkg, version, path) {
+  get_tar_gz_from_file(pkg, version, path)
+}
+get_tar_gz_from_fulltarget_tree <- function(pkg, version, path) {
+  if (file.info(path)$isdir) {
+    path <- file.path(path, pkg)
+    temp_dir <- tempfile()
+    dir.create(temp_dir)
+    pkgbuild::build(
+      path,
+      dest_path = temp_dir,
+      binary = FALSE,
+      manual = FALSE,
+      vignettes = FALSE
+    )
+  } else {
+    untarred_dir <- tempfile()
+    untar(path, exdir = untarred_dir)
+    sources_dirs <- list.dirs(
+      untarred_dir,
+      full.names = TRUE,
+      recursive = FALSE
+    )
+    temp_dir <- tempfile()
+    dir.create(temp_dir)
+    pkgbuild::build(
+      sources_dirs[1],
+      dest_path = temp_dir,
+      binary = FALSE,
+      manual = FALSE,
+      vignettes = FALSE
+    )
+  }
 }
 download_and_add_to_minicran <- function(ref, minicran_path) {
   cli::cli_inform(sprintf("Downloading and adding %s to miniCRAN...", ref))
@@ -258,17 +133,66 @@ download_and_add_to_minicran <- function(ref, minicran_path) {
 
   for (i in seq_len(nrow(x))) {
     if (check_if_pkg_available(x[i, "package"], x[i, "version"])) {
+      # package is available on CRAN, no need to add it to minicran
       next
     }
     if (check_if_added(x[i, "package"], x[i, "version"], minicran_path)) {
+      # package is already added to minicran, no need to add it again
       next
     }
 
-    build_and_add_to_minicran(
+    cli::cli_inform(sprintf(
+      "Processing package: %s version: %s",
+      x[i, "package"],
+      x[i, "version"]
+    ))
+
+    if (file.exists(x[i, "file"])) {
+      cli::cli_inform(sprintf("Using file path: %s", x[i, "file"]))
+      tar_gz_path <- get_tar_gz_from_file(
+        x[i, "package"],
+        x[i, "version"],
+        x[i, "file"]
+      )
+    } else if (file.exists(x[i, "fulltarget"])) {
+      cli::cli_inform(sprintf("Using fulltarget path: %s", x[i, "fulltarget"]))
+      tar_gz_path <- get_tar_gz_from_fulltarget(
+        x[i, "package"],
+        x[i, "version"],
+        x[i, "fulltarget"]
+      )
+    } else if (file.exists(x[i, "fulltarget_tree"])) {
+      cli::cli_inform(sprintf(
+        "Using fulltarget_tree path: %s",
+        x[i, "fulltarget_tree"]
+      ))
+      tar_gz_path <- get_tar_gz_from_fulltarget_tree(
+        x[i, "package"],
+        x[i, "version"],
+        x[i, "fulltarget_tree"]
+      )
+    } else {
+      cli::cli_inform("No file paths found, attempting to get from cache")
+      tar_gz_path <- get_tar_gz_from_cache(
+        x[i, "package"],
+        x[i, "version"]
+      )
+    }
+
+    if (is.null(tar_gz_path)) {
+      cli::cli_warn(sprintf(
+        "Could not find tar.gz for package %s (%s)",
+        x[i, "package"],
+        x[i, "version"]
+      ))
+    } else {
+      cli::cli_inform(sprintf("Found tar.gz at: %s", tar_gz_path))
+    }
+
+    add_to_minicran(
       x[i, "package"],
       x[i, "version"],
-      x[i, "fulltarget"],
-      x[i, "fulltarget_tree"],
+      tar_gz_path,
       minicran_path
     )
   }
@@ -282,17 +206,19 @@ install_and_add_to_minicran <- function(ref, minicran_path) {
 
   for (i in seq_len(nrow(x))) {
     if (check_if_pkg_available(x[i, "package"], x[i, "version"])) {
+      # package is available on CRAN, no need to add it to minicran
       next
     }
     if (check_if_added(x[i, "package"], x[i, "version"], minicran_path)) {
+      # package is already added to minicran, no need to add it again
       next
     }
 
-    build_and_add_to_minicran(
+    tar_gz_path <- get_tar_gz_from_installed(x[i, "package"])
+    add_to_minicran(
       x[i, "package"],
       x[i, "version"],
-      x[i, "fulltarget"],
-      x[i, "fulltarget_tree"],
+      tar_gz_path,
       minicran_path
     )
   }

--- a/script.R
+++ b/script.R
@@ -69,19 +69,13 @@ get_tar_gz_from_installed <- function(pkg) {
   dir.create(tempdir)
   withr::with_dir(tempdir, normalizePath(pkgdepends::pkg_build(pkg)))
 }
-get_tar_gz_from_cache <- function(pkg, version) {
+get_tar_gz_from_cache <- function(pkg, file) {
   i_cache <- pkgcache::pkg_cache_find(
-    package = pkg,
-    version = version,
-    platform = "source"
-  )
-
-  if (nrow(i_cache) == 0) {
-    i_cache <- pkgcache::pkg_cache_find(
-      package = pkg,
-      version = version
+    package = pkg
+  ) |>
+    subset(
+      basename(path) == file
     )
-  }
 
   if (nrow(i_cache) == 0) {
     return(NULL)
@@ -147,7 +141,7 @@ download_and_add_to_minicran <- function(ref, minicran_path) {
       x[i, "version"]
     ))
 
-    if (file.exists(x[i, "file"])) {
+    if (!is.null(x[i, "file"]) && file.exists(x[i, "file"])) {
       cli::cli_inform(sprintf("Using file path: %s", x[i, "file"]))
       tar_gz_path <- get_tar_gz_from_file(
         x[i, "package"],
@@ -175,7 +169,7 @@ download_and_add_to_minicran <- function(ref, minicran_path) {
       cli::cli_inform("No file paths found, attempting to get from cache")
       tar_gz_path <- get_tar_gz_from_cache(
         x[i, "package"],
-        x[i, "version"]
+        basename(x[i, "fulltarget_tree"])
       )
     }
 

--- a/script.R
+++ b/script.R
@@ -46,7 +46,15 @@ check_if_added <- function(pkg, ver = NULL, minicran_path) {
   }
 }
 get_tar_gz <- function(pkg, version, path) {
+  is_valid_tar_gz <- function(file) {
+    res <- try(untar(file, list = TRUE), silent = TRUE)
+    !inherits(res, "try-error")
+  }
   if (grepl(".*.tar.gz$", path)) {
+    # Check if the file is a valid tar archive
+    if (!is_valid_tar_gz(path)) {
+      cli::cli_abort("File {path} is not a valid tar archive.")
+    }
     path
   } else if (grepl(".*.tar.gz-t$", path)) {
     tgz_path <- tempfile(fileext = ".tar.gz")
@@ -56,6 +64,10 @@ get_tar_gz <- function(pkg, version, path) {
       untarred_dir <- tempfile()
       dir.create(untarred_dir)
       on.exit(unlink(untarred_dir, recursive = TRUE), add = TRUE)
+      # Check if the file is a valid tar archive before untarring
+      if (!is_valid_tar_gz(path)) {
+        cli::cli_abort("File {path} is not a valid tar archive.")
+      }
       untar(path, exdir = untarred_dir)
       sources_dir <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
       pkgbuild::build(sources_dir, binary = FALSE, manual = FALSE, vignettes = FALSE, dest_path = tgz_path)

--- a/script.R
+++ b/script.R
@@ -2,16 +2,16 @@
 # The `revdepcheck` package uses the `crancache::install_packages()` function for package installation. This function, in turn, utilizes `utils::install.packages()` and incorporates an additional caching mechanism for efficiency.
 #
 # Current Limitations:
-# Modifying this behavior would require changes to the source code, which is currently not feasible. There is an existing issue on this topic (https://github.com/r-lib/revdepcheck/issues/187), but it's unlikely to be addressed in the near future.
+# Optimising this behavior to use `pak` (and family) would require considerable changes to the source code, which is currently not feasible. There is an existing issue on this topic (https://github.com/r-lib/revdepcheck/issues/187), but it's unlikely to be addressed in the near future.
 #
 # Proposed Solution:
-# The proposed solution is to integrate with the existing workflow by creating a CRAN-like repository. This repository will contain packages from `pak`'s cache, making them accessible via the default `install.packages()` function.
+# The proposed solution is to create cranlike local repo, use `pak` for installation, find its cache and copy the binaries to cranlike repo and finally use this cranlike repo in revdepcheck. This way we can benefit from pak installation features (incl. Remotes, caching, PPM) and still use revdepcheck for reverse dependency checks.
 #
 # Design Overview:
 # 1. Create a CRAN-like repository using the `miniCRAN` package.
-# 2. Install the target package and its reverse dependencies using the `pak` package.
+# 2. Install the target package (both CRAN and DEV) and its reverse dependencies using the `pak` package.
 # 3. If a package is not available on the default CRAN (e.g., it's hosted on GitHub), retrieve the cached binaries and add them to the miniCRAN repository.
-# 4. Run `revdepcheck::revdep_check()` as usual to check reverse dependencies.
+# 4. Run `revdepcheck::revdep_check()` with local CRAN-like repository to check reverse dependencies.
 
 catnl <- function(x = "") cat(sprintf("%s\n", x))
 if_error <- function(x, y = NULL) {
@@ -25,53 +25,137 @@ if_error <- function(x, y = NULL) {
 `%||%` <- function(x, y) {
   if (!length(x) || is.null(x)) y else x
 }
-check_if_pkg_available <- function(pkg, ver = NULL) {
-  length(
-    available.packages(
-      filters = list(
-        add = TRUE,
-        function(db) {
-          if (is.null(ver)) {
-            db[db[, "Package"] == pkg, ]
-          } else {
-            db[db[, "Package"] == pkg & db[, "Version"] == ver, ]
-          }
-        }
-      )
-    )
-  ) > 0
+`%df_empty%` <- function(x, y) {
+  if (is.data.frame(x) && nrow(x) == 0) y else x
 }
-add_to_minicran <- function(x, minicran_path) {
-  temp_dir <- tempfile()
-  on.exit(unlink(temp_dir))
-  dir.create(temp_dir)
-  # for GH packages we have `pkg_1.2.3.9000_hash.tar.gz` so we need to remove the hash and keep only `pkg_1.2.3.9000.tar.gz`
-  new_file_name <- gsub("(.*?_.*)_.*?(\\..*)", "\\1\\2", basename(x))
-  file.copy(x, file.path(temp_dir, new_file_name))
-  miniCRAN::addLocalPackage(gsub("_.*", "", basename(new_file_name)), temp_dir, minicran_path)
+available_packages <- as.data.frame(available.packages())
+check_if_pkg_available <- function(pkg, ver = NULL) {
+  if (is.null(ver)) {
+    nrow(subset(available_packages, Package == pkg)) > 0
+  } else {
+    nrow(subset(available_packages, Package == pkg & Version >= ver)) > 0
+  }
+}
+check_if_added <- function(pkg, ver = NULL, minicran_path) {
+  minicran_ap <- as.data.frame(available.packages(repos = paste0("file:///", minicran_path)))
+  if (nrow(minicran_ap) == 0) return(FALSE)
+  if (is.null(ver)) {
+    nrow(subset(minicran_ap, Package == pkg)) > 0
+  } else {
+    nrow(subset(minicran_ap, Package == pkg & Version == ver)) > 0
+  }
+}
+get_tar_gz <- function(pkg, version, path) {
+  if (grepl(".*.tar.gz$", path)) {
+    path
+  } else if (grepl(".*.tar.gz-t$", path)) {
+    tgz_path <- tempfile(fileext = ".tar.gz")
+    if (file.info(path)$isdir) {
+      pkgbuild::build(file.path(path, pkg), binary = FALSE, manual = FALSE, vignettes = FALSE, dest_path = tgz_path)
+    } else {
+      untarred_dir <- tempfile()
+      dir.create(untarred_dir)
+      on.exit(unlink(untarred_dir, recursive = TRUE), add = TRUE)
+      untar(path, exdir = untarred_dir)
+      sources_dir <- list.dirs(untarred_dir, full.names = TRUE, recursive = FALSE)
+      pkgbuild::build(sources_dir, binary = FALSE, manual = FALSE, vignettes = FALSE, dest_path = tgz_path)
+      tgz_path
+    }
+  } else {
+    cli::cli_abort("Unknown path type: {path}. Expected .tar.gz or .tar.gz-t file.")
+  }
+}
+get_tar_gz_from_cache <- function(pkg, version) {
+  i_cache <- pkgcache::pkg_cache_find(package = pkg, version = version, platform = "source") %df_empty%
+    pkgcache::pkg_cache_find(package = pkg, version = version)
+
+  if (nrow(i_cache) == 0) return(NULL)
+
+  get_tar_gz(pkg, version, i_cache$fullpath[[1]])
+}
+add_to_minicran <- function(pkg, version, tar_gz_path, minicran_path) {
+  cli::cli_inform(sprintf("Adding %s version %s to miniCRAN...", pkg, version))
+
+  if (check_if_added(pkg, version, minicran_path)) {
+    return(invisible(NULL))
+  }
+
+  tempdir <- tempfile()
+  dir.create(tempdir)
+  on.exit(unlink(tempdir, recursive = TRUE), add = TRUE)
+
+  new_file_name <- sprintf("%s_%s.tar.gz", pkg, version)
+  file.copy(tar_gz_path, file.path(tempdir, new_file_name))
+
+  miniCRAN::addLocalPackage(pkg, tempdir, minicran_path)
+
   invisible(NULL)
 }
-add_cache_to_minicran <- function(pkg, version, minicran_path) {
-  i_cache <- pkgcache::pkg_cache_find(package = pkg, version = version, platform = "source")
-  if (nrow(i_cache) == 0) return(invisible(NULL))
-  cli::cli_inform(sprintf("Adding %s to miniCRAN...", pkg))
-  add_to_minicran(i_cache$fullpath[1], minicran_path)
+build_and_add_to_minicran <- function(pkg, version, fulltarget, fulltarget_tree, minicran_path) {
+  cli::cli_inform(sprintf("Building and adding %s version %s to miniCRAN...", pkg, version))
+
+  if (file.exists(fulltarget)) {
+    tgz_path <- fulltarget
+  } else if (file.exists(fulltarget_tree)) {
+    tgz_path <- get_tar_gz(pkg, version, fulltarget_tree)
+  } else {
+    tgz_path <- get_tar_gz_from_cache(pkg, version)
+    if (is.null(tgz_path)) {
+      return(invisible(NULL))
+    }
+  }
+
+  add_to_minicran(pkg, version, tgz_path, minicran_path)
+
+  invisible(NULL)
+}
+download_and_add_to_minicran <- function(ref, minicran_path) {
+  cli::cli_inform(sprintf("Downloading and adding %s to miniCRAN...", ref))
+
+  x <- pak::pkg_download(ref, dependencies = TRUE)
+
+  for (i in seq_len(nrow(x))) {
+    if (check_if_pkg_available(x[i, "package"], x[i, "version"])) {
+      next
+    }
+    if (check_if_added(x[i, "package"], x[i, "version"], minicran_path)) {
+      next
+    }
+
+    build_and_add_to_minicran(
+      x[i, "package"],
+      x[i, "version"],
+      x[i, "fulltarget"],
+      x[i, "fulltarget_tree"],
+      minicran_path
+    )
+  }
+
   invisible(NULL)
 }
 install_and_add_to_minicran <- function(ref, minicran_path) {
   cli::cli_inform(sprintf("Installing and adding %s to miniCRAN...", ref))
-  x <- pak::pkg_install(ref, ask = FALSE)
+
+  x <- pak::pkg_install(ref, ask = FALSE, dependencies = TRUE)
+
   for (i in seq_len(nrow(x))) {
-    i_package <- x$package[i]
-    i_version <- x$version[i]
-    if (check_if_pkg_available(i_package, i_version)) next
-    add_cache_to_minicran(i_package, i_version, minicran_path)
+    if (check_if_pkg_available(x[i, "package"], x[i, "version"])) {
+      next
+    }
+    if (check_if_added(x[i, "package"], x[i, "version"], minicran_path)) {
+      next
+    }
+
+    build_and_add_to_minicran(
+      x[i, "package"],
+      x[i, "version"],
+      x[i, "fulltarget"],
+      x[i, "fulltarget_tree"],
+      minicran_path
+    )
   }
+
   invisible(NULL)
-}
-is_installed_from_gh <- function(package_name) {
-  d <- packageDescription(package_name)
-  (!is.null(d$GithubSHA1)) || identical(d$RemoteType, "github")
 }
 
 args <- commandArgs(trailingOnly = TRUE)
@@ -87,12 +171,6 @@ if (!requireNamespace("pak", quietly = TRUE)) {
 if (!requireNamespace("pkgcache", quietly = TRUE)) {
   install.packages("pkgcache", quiet = TRUE)
 }
-options(
-  repos = c(
-    PPM = pkgcache::repo_resolve("PPM@latest"),
-    getOption("repos")
-  )
-)
 pak::pkg_install(c(
   "cli",
   "miniCRAN",
@@ -102,6 +180,12 @@ pak::pkg_install(c(
   "usethis",
   "yaml"
 ), ask = FALSE)
+options(
+  repos = c(
+    PPM = pkgcache::repo_resolve("PPM@latest"),
+    getOption("repos")
+  )
+)
 
 
 # Read config file
@@ -137,20 +221,24 @@ cli::cli_progress_bar()
 cli::cli_progress_step("Initiating `miniCRAN`...")
 minicran_path <- tempfile()
 dir.create(minicran_path)
-on.exit(unlink(minicran_path, recursive = TRUE))
+on.exit(unlink(minicran_path, recursive = TRUE), add = TRUE)
 # added `rlang` as a dummy package as the `pkgs` arg cannot be empty
-miniCRAN::makeRepo(pkgs = "rlang", path = minicran_path, type = c("source", .Platform$pkgType))
+miniCRAN::makeRepo(pkgs = "rlang", path = minicran_path, type = c("source", .Platform$pkgType), quiet = TRUE)
 # add minicran repo path to repos so that revdepcheck can use it
 # this is the directory where we will store packages from config file
 options("repos" = c(
   "minicran" = paste0("file:///", minicran_path),
   getOption("repos")
 ))
+#Sys.setenv(CRANCACHE_REPOS = "minicran, cran, bioc")
 
-### install pkg - only if not available
-pkg_name <- read.dcf("DESCRIPTION")[, "Package"]
-if (isFALSE(check_if_pkg_available(pkg_name))) {
-  cli::cli_progress_step("Adding GH release to miniCRAN...")
+## installing the package
+### CRAN version
+cli::cli_progress_step("Installing CRAN version of the package...")
+pkg_name <- read.dcf("DESCRIPTION")[1, "Package"][[1]]
+if (check_if_pkg_available(pkg_name)) {
+  pkg_ref_released <- pkg_name
+} else {
   # try to get the package reference from the DESCRIPTION file (URL field)
   pkg_url <- gsub("\n|/$", "", strsplit(read.dcf("DESCRIPTION")[1, "URL"], ",")[[1]])
   pkg_url_gh <- grep("github.com", pkg_url, value = TRUE)
@@ -159,17 +247,13 @@ if (isFALSE(check_if_pkg_available(pkg_name))) {
     cli::cli_abort("Unable to automatically determine the package reference for GitHub release.")
     return(NULL)
   }
-  install_and_add_to_minicran(pkg_ref_released, minicran_path)
 }
-
-### add pkgs from GH to miniCRAN
-cli::cli_progress_step("Adding packages from GH to miniCRAN...")
-x <- pkgdepends::new_pkg_deps("deps::.")
-x$resolve()
-pkgs_from_gh <- Filter(is_installed_from_gh, Filter(function(x) x %in% rownames(installed.packages()), unique(x$get_resolution()$package)))
-for (pkg in pkgs_from_gh) {
-  add_cache_to_minicran(pkg, installed.packages()[pkg, "Version"], minicran_path)
-}
+cli::cli_inform(sprintf("Using package reference: %s", pkg_ref_released))
+install_and_add_to_minicran(pkg_ref_released, minicran_path)
+### DEV version
+cli::cli_progress_step("Installing DEV version of the package...")
+pkg_ref_dev <- "."
+install_and_add_to_minicran(pkg_ref_dev, minicran_path)
 
 ## revdepcheck
 cli::cli_progress_step("Initiating `revdepcheck`...")
@@ -189,12 +273,17 @@ cli::cli_progress_bar("Adding refs to revdepcheck", total = length(refs))
 for (ref in refs) {
   cli::cli_progress_message("Adding {ref}...")
 
-  install_and_add_to_minicran(ref, minicran_path)
+  tryCatch({
+    download_and_add_to_minicran(ref, minicran_path)
 
-  ref_pkg <- pkgdepends::parse_pkg_ref(ref)$package
-  revdepcheck::revdep_add(packages = ref_pkg)
+    ref_pkg <- pkgdepends::parse_pkg_ref(ref)$package
+    revdepcheck::revdep_add(packages = ref_pkg)
 
-  cli::cli_inform("Added {ref} to revdep todo!")
+    cli::cli_inform("Added {ref} to revdep todo!")
+  }, error = function(e) {
+    cli::cli_warn(sprintf("Failed to download and add %s to miniCRAN: %s", ref, e$message))
+  })
+
   cli::cli_progress_update()
 }
 cli::cli_progress_done()
@@ -204,9 +293,13 @@ cli::cli_inform("The current revdep todo (empty indicates the default - all revd
 print(revdepcheck::revdep_todo())
 
 
+cli::cli_h1("miniCRAN status")
+miniCRAN::pkgAvail(repos = minicran_path)[, c("Package", "Version")]
+
+
 # Execute
 cli::cli_h1("Execute revdepcheck")
-revdepcheck::revdep_check(num_workers = number_of_workers, timeout = timeout)
+revdepcheck::revdep_check(num_workers = number_of_workers, timeout = timeout, quiet = FALSE)
 
 
 # Print results
@@ -250,4 +343,6 @@ if (length(revdepcheck::revdep_summary())) {
   print("(empty)")
 }
 
-stopifnot(identical(readLines("revdep/problems.md", warn = FALSE), "*Wow, no problems at all. :)*"))
+if (!identical(readLines("revdep/problems.md", warn = FALSE), "*Wow, no problems at all. :)*")) {
+  stop("There are errors. Please refer to the logs above.")
+}


### PR DESCRIPTION
- use `pak` for downloading and installing
  - unfortunately `pak` gives ambiguous download results - sometimes it gives `.tar.gz`, sometimes compressed files etc. A lot of code in this PR is to handle this.
- add error condition if fails on install - basically we succeed only if everything (!) is checked and everything (!) is ok